### PR TITLE
Delete distutils imports for use with python 3.12

### DIFF
--- a/notifications/base/models.py
+++ b/notifications/base/models.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=too-many-lines
-from distutils.version import \
-    StrictVersion  # pylint: disable=no-name-in-module,import-error
-
+from packaging.version import Version
 from django import get_version
 from django.conf import settings
 from django.contrib.auth.models import Group
@@ -21,7 +19,7 @@ from notifications.signals import notify
 from notifications.utils import id2slug
 from swapper import load_model
 
-if StrictVersion(get_version()) >= StrictVersion('1.8.0'):
+if Version(get_version()) >= Version('1.8.0'):
     from django.contrib.contenttypes.fields import GenericForeignKey  # noqa
 else:
     from django.contrib.contenttypes.generic import GenericForeignKey  # noqa

--- a/notifications/templatetags/notifications_tags.py
+++ b/notifications/templatetags/notifications_tags.py
@@ -1,7 +1,6 @@
 ''' Django notifications template tags file '''
 # -*- coding: utf-8 -*-
-from distutils.version import StrictVersion  # pylint: disable=no-name-in-module,import-error
-
+from packaging.version import Version
 from django import get_version
 from django.template import Library
 from django.utils.html import format_html
@@ -32,7 +31,7 @@ def notifications_unread(context):
     return get_cached_notification_unread_count(user)
 
 
-if StrictVersion(get_version()) >= StrictVersion('2.0'):
+if Version(get_version()) >= Version('2.0'):
     notifications_unread = register.simple_tag(takes_context=True)(notifications_unread)  # pylint: disable=invalid-name
 else:
     notifications_unread = register.assignment_tag(takes_context=True)(notifications_unread)  # noqa

--- a/notifications/tests/urls.py
+++ b/notifications/tests/urls.py
@@ -1,13 +1,13 @@
 ''' Django notification urls for tests '''
 # -*- coding: utf-8 -*-
-from distutils.version import StrictVersion  # pylint: disable=no-name-in-module,import-error
+from packaging.version import Version # pylint: disable=no-name-in-module,import-error
 
 from django import get_version
 from django.contrib import admin
 from notifications.tests.views import (live_tester,  # pylint: disable=no-name-in-module,import-error
                                        make_notification)
 
-if StrictVersion(get_version()) >= StrictVersion('2.1'):
+if Version(get_version()) >= Version('2.1'):
     from django.urls import include, path  # noqa
     from django.contrib.auth.views import LoginView
     urlpatterns = [
@@ -17,7 +17,7 @@ if StrictVersion(get_version()) >= StrictVersion('2.1'):
         path('admin/', admin.site.urls),
         path('', include('notifications.urls', namespace='notifications')),
     ]
-elif StrictVersion(get_version()) >= StrictVersion('2.0') and StrictVersion(get_version()) < StrictVersion('2.1'):
+elif Version(get_version()) >= Version('2.0') and Version(get_version()) < Version('2.1'):
     from django.urls import include, path  # noqa
     from django.contrib.auth.views import login
     urlpatterns = [

--- a/notifications/urls.py
+++ b/notifications/urls.py
@@ -1,12 +1,11 @@
 ''' Django notification urls file '''
 # -*- coding: utf-8 -*-
-from distutils.version import StrictVersion  # pylint: disable=no-name-in-module,import-error
-
+from packaging.version import Version
 from django import get_version
 
 from . import views
 
-if StrictVersion(get_version()) >= StrictVersion('2.0'):
+if Version(get_version()) >= Version('2.0'):
     from django.urls import re_path as pattern
 else:
     from django.conf.urls import url as pattern

--- a/notifications/views.py
+++ b/notifications/views.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 ''' Django Notifications example views '''
-from distutils.version import \
-    StrictVersion  # pylint: disable=no-name-in-module,import-error
-
+from packaging.version import Version
 from django import get_version
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
@@ -20,7 +18,7 @@ from notifications.utils import slug2id
 
 Notification = load_model('notifications', 'Notification')
 
-if StrictVersion(get_version()) >= StrictVersion('1.7.0'):
+if Version(get_version()) >= Version('1.7.0'):
     from django.http import JsonResponse  # noqa
 else:
     # Django 1.6 doesn't have a proper JsonResponse

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,7 @@
 import ast
 import re
 
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup  # pylint: disable=no-name-in-module,import-error
+from setuptools import setup
 
 
 _version_re = re.compile(r'__version__\s+=\s+(.*)')  # pylint: disable=invalid-name


### PR DESCRIPTION
All distutils imports are removed to ensure compatibility with Python 3.12.